### PR TITLE
Update Readme.md Usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ createThumbnail({
   url: '<path to video file>',
   timeStamp: 10000,
 })
-  .then(response => console.log({ response }));
+  .then(response => console.log({ response }))
   .catch(err => console.log({ err }));
 ```
 


### PR DESCRIPTION
Under usage section, where a small example is there on how to use the library, there is an extra semicolon after then clause, if semicolon will be there, then that catch clause won't be a part of the promise and will create error.