### PR TITLE
Add mimetype and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ createThumbnail({
 | Property |   Type   | Description                 |
 | -------- | :------: | :-------------------------- |
 | path     | `String` | Path to generated thumbnail |
+| size     | `Number` | Size (in bytes) of thumbnail|
+| mime     | `String` | Mimetype of thumbnail       |
 | width    | `Number` | Thumbnail width             |
 | height   | `Number` | Thumbnail height            |
 

--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -77,6 +77,8 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
 
             WritableMap map = Arguments.createMap();
             map.putString("path", "file://" + thumbnailDir + '/' + fileName);
+            map.putDouble("size", image.getByteCount());
+            map.putString("mime", "image/" + format);
             map.putDouble("width", image.getWidth());
             map.putDouble("height", image.getHeight());
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,8 @@ declare module "react-native-create-thumbnail" {
 
   export interface Thumbnail {
     path: string;
+    size: number;
+    mime: string;
     width: number;
     height: number;
   }

--- a/ios/CreateThumbnail.m
+++ b/ios/CreateThumbnail.m
@@ -54,6 +54,8 @@ RCT_EXPORT_METHOD(create:(NSDictionary *)config findEventsWithResolver:(RCTPromi
         [fileManager createFileAtPath:fullPath contents:data attributes:nil];
         resolve(@{
             @"path"     : fullPath,
+            @"size"     : [NSNumber numberWithFloat: data.length],
+            @"mime"     : [NSString stringWithFormat: @"image/%@", format],
             @"width"    : [NSNumber numberWithFloat: thumbnail.size.width],
             @"height"   : [NSNumber numberWithFloat: thumbnail.size.height]
         });


### PR DESCRIPTION
Hello,
I needed a couple of extra attributes in the response. Namely the mimetype and the size. I realize this might have been doable with RNFS but it seems like one less step just to do it here. I thought maybe others could find utility in this also.