### PR TITLE
fix: xcode 12 build errors

### DIFF
--- a/react-native-create-thumbnail.podspec
+++ b/react-native-create-thumbnail.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   # ...
   # s.dependency "..."
 end


### PR DESCRIPTION
Native APIs actually reside on the React-Core pod instead. This leads to build errors when making use of use_frameworks! in your podfile.
See: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116