### PR TITLE
Remove URI decode to avoid crashes on android

### DIFF
--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -140,7 +140,7 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
     private static Bitmap getBitmapAtTime(Context context, String filePath, int time, Map headers) {
         MediaMetadataRetriever retriever = new MediaMetadataRetriever();
         if (URLUtil.isFileUrl(filePath)) {
-            retriever.setDataSource(Uri.decode(filePath).replace("file://", ""));
+            retriever.setDataSource(filePath.replace("file://", ""));
         } else if (filePath.contains("content://")) {
             retriever.setDataSource(context, Uri.parse(filePath));
         } else {

--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -140,7 +142,14 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
     private static Bitmap getBitmapAtTime(Context context, String filePath, int time, Map headers) {
         MediaMetadataRetriever retriever = new MediaMetadataRetriever();
         if (URLUtil.isFileUrl(filePath)) {
-            retriever.setDataSource(filePath.replace("file://", ""));
+            String decodedPath;
+            try {
+                decodedPath = URLDecoder.decode(filePath, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                decodedPath = filePath;
+            }
+
+            retriever.setDataSource(decodedPath.replace("file://", ""));
         } else if (filePath.contains("content://")) {
             retriever.setDataSource(context, Uri.parse(filePath));
         } else {


### PR DESCRIPTION
While using this package I was facing a crash when trying to create a thumbnail for a video with the character `%` on the file path.

By removing the `Uri.decode` call, the crash stopped happening.

Is there any down side of removing it?