### PR TITLE
Fix compileSdkVersion 33 compile error

### DIFF
--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -189,7 +189,12 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
         }
   
         Bitmap image = retriever.getFrameAtTime(time * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
-        retriever.release();
+        try {
+            retriever.release();
+        } catch (Exception e) {
+            // Do nothing. see: https://developer.android.com/reference/android/media/MediaMetadataRetriever#release()
+        }
+
         if (image == null) {
             throw new IllegalStateException("File doesn't exist or not supported");
         }


### PR DESCRIPTION
When compiling the project with compile SDK version set to 33 (Android 13) a compile error occurs.

Fix for https://github.com/souvik-ghosh/react-native-create-thumbnail/issues/76