### PR TITLE
Request frame-accurate image generation on iOS

### DIFF
--- a/ios/CreateThumbnail.m
+++ b/ios/CreateThumbnail.m
@@ -113,7 +113,9 @@ RCT_EXPORT_METHOD(create:(NSDictionary *)config findEventsWithResolver:(RCTPromi
 - (void) generateThumbImage:(AVURLAsset *)asset atTime:(int)timeStamp completion:(void (^)(UIImage* thumbnail))completion failure:(void (^)(NSError* error))failure {
     AVAssetImageGenerator *generator = [[AVAssetImageGenerator alloc] initWithAsset:asset];
     generator.appliesPreferredTrackTransform = YES;
-    generator.maximumSize = CGSizeMake(512, 512);
+    generator.maximumSize = CGSizeMake(512, 512);    
+    generator.requestedTimeToleranceBefore = CMTimeMake(0, 1000);
+    generator.requestedTimeToleranceAfter = CMTimeMake(0, 1000);
     CMTime time = CMTimeMake(timeStamp, 1000);
     AVAssetImageGeneratorCompletionHandler handler = ^(CMTime timeRequested, CGImageRef image, CMTime timeActual, AVAssetImageGeneratorResult result, NSError *error) {
         if (result == AVAssetImageGeneratorSucceeded) {


### PR DESCRIPTION
This would fix #79. See:
* https://developer.apple.com/documentation/avfoundation/avassetimagegenerator/1390571-requestedtimetolerancebefore
* https://developer.apple.com/documentation/avfoundation/avassetimagegenerator/1387751-requestedtimetoleranceafter

Per the docs, "this may incur additional decoding delay." This hasn't been noticeable in my use cases, but I have been testing with relatively shorter videos.