### PR TITLE
fix: build failures for android SDK 33 

### DIFF
--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -189,7 +189,11 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
         }
   
         Bitmap image = retriever.getFrameAtTime(time * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
-        retriever.release();
+        try {
+            retriever.release();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
         if (image == null) {
             throw new IllegalStateException("File doesn't exist or not supported");
         }


### PR DESCRIPTION
## Issue

```
/.../app/node_modules/react-native-create-thumbnail/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java:192: error: unreported exception IOException; must be caught or declared to be thrown
        retriever.release();
                         ^
Note: /.../app/node_modules/react-native-create-thumbnail/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java uses or overrides a deprecated API.
```


