### PR TITLE
feat: allow user to specify how Android target frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ createThumbnail({
 | headers   |         `Object`          | Headers to load the video with. e.g. `{ Authorization: 'someAuthToken' }` |
 | cacheName   |         `String` (optional)          | Cache name for this thumbnail to avoid duplicate generation. If specified, and a thumbnail already exists with the same cache name, it will be returned instead of generating a new one. |
 | timeToleranceMs | `Number` (default `2000`, Only iOS) | Time tolerance in ms for the system to pick the best matching video frame |
+| onlySyncedFrames | `Boolean` (default `true`, Only Android) | Specify how Android target frames. Use `true` to retrieve a sync frame that has a timestamp closest to the specified one. Use `false` to retrieve a frame that may or may not be a sync frame but is closest to the specified timestamp. |
 
 ## Response Object
 

--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -90,13 +90,14 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
             int timeStamp = options.hasKey("timeStamp") ? options.getInt("timeStamp") : 0;
             int maxWidth = options.hasKey("maxWidth") ? options.getInt("maxWidth") : 512;
             int maxHeight = options.hasKey("maxHeight") ? options.getInt("maxHeight") : 512;
+            boolean onlySyncedFrames = options.hasKey("onlySyncedFrames") ? options.getBoolean("onlySyncedFrames") : true;
             HashMap headers = options.hasKey("headers") ? options.getMap("headers").toHashMap() : new HashMap<String, String>();
             String fileName = TextUtils.isEmpty(cacheName) ? ("thumb-" + UUID.randomUUID().toString()) : cacheName + "." + format;
             OutputStream fOut = null;
             try {
                 File file = new File(cacheDir, fileName);
                 Context context = weakContext.get();
-                Bitmap image = getBitmapAtTime(context, filePath, timeStamp, maxWidth, maxHeight, headers);
+                Bitmap image = getBitmapAtTime(context, filePath, timeStamp, maxWidth, maxHeight, onlySyncedFrames, headers);
                 file.createNewFile();
                 fOut = new FileOutputStream(file);
 
@@ -170,7 +171,7 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
         return dir;
     }
 
-    private static Bitmap getBitmapAtTime(Context context, String filePath, int time, int maxWidth, int maxHeight, Map headers) throws IOException, IllegalStateException {
+    private static Bitmap getBitmapAtTime(Context context, String filePath, int time, int maxWidth, int maxHeight, boolean onlySyncedFrames, Map headers) throws IOException, IllegalStateException {
         MediaMetadataRetriever retriever = new MediaMetadataRetriever();
         if (URLUtil.isFileUrl(filePath)) {
             String decodedPath;
@@ -190,7 +191,7 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
             retriever.setDataSource(filePath, headers);
         }
   
-        Bitmap image = retriever.getScaledFrameAtTime(time * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, maxWidth, maxHeight);
+        Bitmap image = retriever.getScaledFrameAtTime(time * 1000, onlySyncedFrames ? MediaMetadataRetriever.OPTION_CLOSEST_SYNC : MediaMetadataRetriever.OPTION_CLOSEST, maxWidth, maxHeight);
         try {
             retriever.release();
         } catch(IOException e) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,14 @@ declare module "react-native-create-thumbnail" {
     cacheName?: string;
     maxWidth?: number;
     maxHeight?: number;
+    /**
+     * iOS Only
+     */
     timeToleranceMs?: number;
+    /**
+     * Android Only
+     */
+    onlySyncedFrames?: boolean;
   }
 
   export interface Thumbnail {


### PR DESCRIPTION
As of now Android targets only synced frames. Therefore it sometimes doesn't return the exact frame requested by the user. With `onlySyncedFrames = false` user can now request exact frames.