### PR TITLE
Added IllegalStateException to catch block

### DIFF
--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -58,7 +58,7 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
                 handler.post(() -> {
                     promise.resolve(data);
                 });
-            } catch (IOException e) {
+            } catch (IOException | IllegalStateException e) {
                 handler.post(() -> {
                     promise.reject("CreateThumbnail_ERROR", e);
                 });


### PR DESCRIPTION
Thanks for your work on this awesome library!

The `IllegalStateException` thrown on [line #200](https://github.com/souvik-ghosh/react-native-create-thumbnail/blob/master/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java#L200) is not caught by the top level try / catch, causing the app to crash in cases where a thumbnail could not be generated, as seen in [this issue](https://github.com/souvik-ghosh/react-native-create-thumbnail/issues/116). 