### PR TITLE
fix(android): AGP 8 and RN 0.71+ gradle compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
-    lintOptions {
+    lint {
         abortOnError false
     }
 }
@@ -77,7 +77,7 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation 'com.facebook.react:react-native:+'  // From node_modules
+    implementation 'com.facebook.react:react-android:+'  // From node_modules
     implementation 'commons-io:commons-io:2.8.0'
 }
 


### PR DESCRIPTION
Some minor updates to make this library easier to use under newer RN versions (I'm currently using 0.83 in my app):

- Rename deprecated 'lintOptions' block to 'lint' for AGP 8+.
- Switch dependency from 'com.facebook.react:react-native' to 'com.facebook.react:react-android', which is the artifact name used by React Native 0.71 and newer.