### PR TITLE
feat: add configurable thumbnail quality option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ createThumbnail({
 | format    | `String` (default `jpeg`) | Thumbnail format, can be one of: `jpeg`, or `png`                         |
 | maxWidth  | `Number` (default `512`)  | Max thumbnail width in px                                                 |
 | maxHeight | `Number` (default `512`)  | Max thumbnail height in px                                                |
+| quality   | `Number` (default `90`)   | Thumbnail quality                                                         |
 | dirSize   | `Number` (default `100`)  | Maximum size of the cache directory (in megabytes). When this directory is full, the previously generated thumbnails will be deleted to clear about half of it's size.                        |
 | headers   |         `Object`          | Headers to load the video with. e.g. `{ Authorization: 'someAuthToken' }` |
 | cacheName   |         `String` (optional)          | Cache name for this thumbnail to avoid duplicate generation. If specified, and a thumbnail already exists with the same cache name, it will be returned instead of generating a new one. |

--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -91,6 +91,7 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
         int timeStamp = options.hasKey("timeStamp") ? options.getInt("timeStamp") : 0;
         int maxWidth = options.hasKey("maxWidth") ? options.getInt("maxWidth") : 512;
         int maxHeight = options.hasKey("maxHeight") ? options.getInt("maxHeight") : 512;
+        int quality = options.hasKey("quality") ? options.getInt("quality") : 90;
         boolean onlySyncedFrames = options.hasKey("onlySyncedFrames") ? options.getBoolean("onlySyncedFrames") : true;
         HashMap headers = options.hasKey("headers") ? options.getMap("headers").toHashMap() : new HashMap<String, String>();
         String fileName = TextUtils.isEmpty(cacheName) ? ("thumb-" + UUID.randomUUID().toString()) : cacheName + "." + format;
@@ -101,11 +102,10 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
         file.createNewFile();
         fOut = new FileOutputStream(file);
 
-        // 100 means no compression, the lower you go, the stronger the compression
         if (format.equals("png")) {
-            image.compress(Bitmap.CompressFormat.PNG, 100, fOut);
+            image.compress(Bitmap.CompressFormat.PNG, quality, fOut);
         } else {
-            image.compress(Bitmap.CompressFormat.JPEG, 90, fOut);
+            image.compress(Bitmap.CompressFormat.JPEG, quality, fOut);
         }
 
         fOut.flush();

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare module "react-native-create-thumbnail" {
     cacheName?: string;
     maxWidth?: number;
     maxHeight?: number;
+    quality?: number;
     /**
      * iOS Only
      */

--- a/ios/CreateThumbnail.m
+++ b/ios/CreateThumbnail.m
@@ -14,6 +14,7 @@ RCT_EXPORT_METHOD(create:(NSDictionary *)config findEventsWithResolver:(RCTPromi
     NSDictionary *headers = config[@"headers"] ?: @{};
     CGFloat maxWidth = [config[@"maxWidth"] floatValue] ?: 512;
     CGFloat maxHeight = [config[@"maxHeight"] floatValue] ?: 512;
+    CGFloat quality = [config[@"quality"] floatValue] ?: 90;
     int timeToleranceMs = [config[@"timeToleranceMs"] intValue] ?: 2000;
 
     unsigned long long cacheDirSize = dirSize * 1024 * 1024;
@@ -61,7 +62,7 @@ RCT_EXPORT_METHOD(create:(NSDictionary *)config findEventsWithResolver:(RCTPromi
             if ([format isEqual: @"png"]) {
                 data = UIImagePNGRepresentation(thumbnail);
             } else {
-                data = UIImageJPEGRepresentation(thumbnail, 1.0);
+                data = UIImageJPEGRepresentation(thumbnail, quality / 100);
             }
 
             NSFileManager *fileManager = [NSFileManager defaultManager];


### PR DESCRIPTION
Introduces a new 'quality' option (default 90) for both Android and iOS. It controls the JPEG/PNG compression level passed to Bitmap.compress on Android and the UIImageJPEGRepresentation compressionQuality on iOS.